### PR TITLE
fix: now is detected if is running under node or ts-node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ migrations
 migrations.json
 *.log
 coverage
+distexamples

--- a/examples/cli.ts
+++ b/examples/cli.ts
@@ -1,11 +1,11 @@
 import { mongoMigrateCli } from '../lib';
 
 mongoMigrateCli({
-  uri: 'mongodb://username:password@0.0.0.0:27017',
+  uri: 'mongodb://admin:admin@0.0.0.0:27017',
   database: 'db',
   migrationsDir: `${__dirname}/migrations`,
   migrationsCollection: 'migrations_collection',
   options: {
-    useUnifiedTopology: true
-  }
+    useUnifiedTopology: true,
+  },
 });

--- a/examples/migrations/1585933701415_Migration.ts
+++ b/examples/migrations/1585933701415_Migration.ts
@@ -1,12 +1,12 @@
 import { Db } from 'mongodb';
 import { MigrationInterface } from '../../lib';
 
-export class MigrationExample implements MigrationInterface {
+export class Migration1585933701415 implements MigrationInterface {
   public async up(db: Db): Promise<any> {
-    await db.createCollection('example');
+    db.createCollection('mycol');
   }
 
   public async down(db: Db): Promise<any> {
-    await db.dropCollection('example');
+    db.dropCollection('mycol');
   }
 }

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -6,7 +6,7 @@ import { status } from './commands/status';
 import { up } from './commands/up';
 import { Config } from './config';
 
-export const cli = (config: Config) => {
+export const cli = (config: Config): void => {
   const program = new Command();
 
   program
@@ -21,14 +21,11 @@ export const cli = (config: Config) => {
     .description('Create a new migration file under migrations directory')
     .option('--name <name>', 'the migration name')
     .action((cmd: Command) => {
-      if (!cmd.opts) {
-        program.help();
-      }
+      const opts = cmd.opts();
+      let name = opts.name;
 
-      const { name } = cmd.opts();
-
-      if (typeof name !== 'string') {
-        cmd.help();
+      if (typeof opts.name !== 'string' || opts.name.length === 0) {
+        name = undefined;
       }
 
       newCommand({ migrationName: name, migrationsDir: config.migrationsDir });
@@ -67,8 +64,4 @@ export const cli = (config: Config) => {
     });
 
   program.parse(process.argv);
-
-  if (program.args.length === 0) {
-    program.outputHelp();
-  }
 };

--- a/lib/commands/init.ts
+++ b/lib/commands/init.ts
@@ -1,25 +1,30 @@
 import * as fs from 'fs';
 import { getDefaultConfigPath } from '../config';
+import ora from 'ora';
 
 const initConfig = {
   uri: 'mongodb://username:password@host:27017',
   database: 'db',
   options: {
     useNewUrlParser: true,
-    useUnifiedTopology: true
+    useUnifiedTopology: true,
   },
   migrationsDir: 'migrations',
-  migrationsCollection: 'migrations_changelog'
+  migrationsCollection: 'migrations_changelog',
 };
 
-export const init = () => {
+export const init = (): void => {
   const configPath = getDefaultConfigPath();
+  const spinner = ora('Initializing config').start();
+  const migrationsDir = `${process.env.PWD}/${initConfig.migrationsDir}`;
 
-  if (!fs.existsSync(`${process.env.PWD}/${initConfig.migrationsDir}`)) {
-    fs.mkdirSync(`${process.env.PWD}/${initConfig.migrationsDir}`);
+  if (!fs.existsSync(migrationsDir)) {
+    fs.mkdirSync(migrationsDir);
   }
 
   if (!fs.existsSync(configPath)) {
     fs.writeFileSync(configPath, JSON.stringify(initConfig, null, 2));
   }
+
+  spinner.succeed('Config initialized').stop();
 };

--- a/lib/commands/new.ts
+++ b/lib/commands/new.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 
 interface CommandNewOptions {
   migrationsDir: string;
-  migrationName: string;
+  migrationName?: string;
 }
 
 export const migrationTemplate = (className: string) => {
@@ -26,9 +26,10 @@ export const newCommand = (opts: CommandNewOptions): string => {
     fs.mkdirSync(migrationsDir);
   }
 
-  const className = `M${+new Date()}_${migrationName}`;
+  const fileName = `${+new Date()}_${migrationName || 'Migration'}`;
+  const className = `${migrationName || 'Migration'}${+new Date()}`;
   const template = migrationTemplate(className);
-  const migrationPath = `${migrationsDir}/${className}.ts`;
+  const migrationPath = `${migrationsDir}/${fileName}.ts`;
 
   fs.writeFileSync(migrationPath, template);
 

--- a/lib/utils/isTsNode.ts
+++ b/lib/utils/isTsNode.ts
@@ -2,5 +2,5 @@
 export const isTsNode = (): boolean => {
   const symbol = Symbol.for('ts-node.register.instance');
 
-  return (process as any)[symbol] !== undefined;
+  return !!(process as any)[symbol];
 };

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
   },
   "dependencies": {
     "cli-table": "^0.3.1",
-    "commander": "^4.0.1",
-    "mongodb": "^3.4.0",
+    "commander": "^5.0.0",
+    "mongodb": "^3.5.5",
     "ora": "^4.0.3"
   },
   "husky": {

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "commonjs",
+    "target": "esnext",
+    "lib": ["es6"],
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "declaration": true
+  },
+  "exclude": ["node_modules", "dist", "__tests__"],
+  "include": ["lib/**/*", "examples/**/*"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1900,10 +1900,10 @@ commander@^2.20.0, commander@~2.20.3:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
-  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+commander@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-5.0.0.tgz#dbf1909b49e5044f8fdaf0adc809f0c0722bdfd0"
+  integrity sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -2202,7 +2202,7 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -3568,7 +3568,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -4905,11 +4905,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -4918,32 +4913,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._root@~3.0.0:
   version "3.0.1"
@@ -4989,11 +4962,6 @@ lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -5401,7 +5369,7 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-mongodb@^3.4.0:
+mongodb@^3.5.5:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.5.5.tgz#1334c3e5a384469ac7ef0dea69d59acc829a496a"
   integrity sha512-GCjDxR3UOltDq00Zcpzql6dQo1sVry60OXJY3TDmFc2SWFY6c8Gn1Ardidc5jDirvJrx2GC3knGOImKphbSL3A==


### PR DESCRIPTION
- The migrations name are generated in other way and the `name` option when using the cli is now optional.
- Fix a problem when running with node and had the type definitions inside the bundle