### PR TITLE
fix(#32): :bug: only load config when needed and fixed relative path to support win 10

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
 import { cli } from '../lib/cli';
-import { getDefaultConfigPath, readConfigFromFile } from '../lib/config';
 
-const config = readConfigFromFile(getDefaultConfigPath());
-cli(config);
+cli();

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -4,9 +4,13 @@ import { init } from './commands/init';
 import { newCommand } from './commands/new';
 import { status } from './commands/status';
 import { up } from './commands/up';
-import { Config } from './config';
+import { Config,getDefaultConfigPath, readConfigFromFile } from './config';
 
-export const cli = (config: Config): void => {
+export const getConfig = (): Config => {
+  return readConfigFromFile(getDefaultConfigPath());
+}
+
+export const cli = (): void => {
   const program = new Command();
 
   program
@@ -22,6 +26,7 @@ export const cli = (config: Config): void => {
     .storeOptionsAsProperties(false)
     .option('-n, --name <name>', 'the migration name')
     .action((cmd: Command) => {
+      const config = getConfig()
       const opts = cmd.opts();
 
       let name = opts.name;
@@ -37,6 +42,7 @@ export const cli = (config: Config): void => {
     .command('up')
     .description('Run all pending migrations')
     .action(async () => {
+      const config = getConfig()
       try {
         await up({ config });
       } catch (e) {
@@ -53,6 +59,7 @@ export const cli = (config: Config): void => {
     .option('-l, --last', 'Undo the last applied migration')
     .option('-a, --all', 'Undo all applied migrations')
     .action((cmd: Command) => {
+      const config = getConfig()
       const opts = cmd.opts();
       if (!opts.last && !opts.all) {
         cmd.outputHelp();
@@ -69,6 +76,7 @@ export const cli = (config: Config): void => {
     .command('status')
     .description('Show the status of the migrations')
     .action(() => {
+      const config = getConfig()
       status({ config });
     });
 

--- a/lib/commands/init.ts
+++ b/lib/commands/init.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
-import { getDefaultConfigPath } from '../config';
+import * as path from 'path';
+import { getCurrentWorkingDirectory, getDefaultConfigPath } from '../config';
 import ora from 'ora';
 
 const initConfig = {
@@ -16,7 +17,7 @@ const initConfig = {
 export const init = (): void => {
   const configPath = getDefaultConfigPath();
   const spinner = ora('Initializing config').start();
-  const migrationsDir = `${process.env.PWD}/${initConfig.migrationsDir}`;
+  const migrationsDir = path.join(getCurrentWorkingDirectory(), initConfig.migrationsDir);
 
   if (!fs.existsSync(migrationsDir)) {
     fs.mkdirSync(migrationsDir);

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as path from 'path';
 import { MongoClientOptions } from 'mongodb';
 import { getDbFromUri } from './utils/getDbFromUri';
 
@@ -40,11 +41,14 @@ export const readConfigFromFile = (filePath: string): Config => {
   return config;
 };
 
+export const getCurrentWorkingDirectory = (): string =>
+  process.env.PWD || process.cwd()
+
 export const getDefaultConfigPath = (): string =>
-  `${process.env.PWD}/${DEFAULT_CONFIG_FILENAME}`;
+  path.join(getCurrentWorkingDirectory(), DEFAULT_CONFIG_FILENAME);
 
 export const getDefaultMigrationsDir = (): string =>
-  `${process.env.PWD}/${DEFAULT_MIGRATIONS_DIR}`;
+  path.join(getCurrentWorkingDirectory(), DEFAULT_MIGRATIONS_DIR);
 
 const getConfigFromEnv = (
   config: Config


### PR DESCRIPTION
This PR fixed the following bug:

---------------------------------
**Describe the bug**
This relates to #32 . Running the `init `command fails since the cli expects a configuration when instantiated.

**To Reproduce**
Steps to reproduce the behavior:
1. install the library in a new project
2. run the init command

**Expected behavior**
After installing the library, a user should be able to initialize a new migrations folder/configuration.

---------------------------------

It also fixed issues on Windows 10, where `process.env.PWD` is not defined ([more info here](https://github.com/nodejs/help/issues/1881)) and uses `path.join()` to concatenate paths instead of raw string concatenation.
