### PR TITLE
fix(#32): cli does not require config if init has not ran yet

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -2,10 +2,16 @@
 
 import { cli } from '../lib/cli';
 import { getDefaultConfigPath, readConfigFromFile } from '../lib/config';
+import { ConfigFileNotFoundError } from '../lib/errors/ConfigFileNotFoundError';
 
 try {
   const config = readConfigFromFile(getDefaultConfigPath());
   cli(config);
-} catch {
-  cli();
+} catch (e) {
+  if (e instanceof ConfigFileNotFoundError) {
+    console.warn(`${e.message} Initializing CLI without config.`);
+    cli();
+  } else {
+    console.error(e);
+  }
 }

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -2,7 +2,7 @@
 
 import { cli } from '../lib/cli';
 import { getDefaultConfigPath, readConfigFromFile } from '../lib/config';
-import { ConfigFileNotFoundError } from '../lib/errors/ConfigFileNotFoundError';
+import { ConfigFileNotFoundError } from '../lib/errors';
 
 try {
   const config = readConfigFromFile(getDefaultConfigPath());

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -3,5 +3,9 @@
 import { cli } from '../lib/cli';
 import { getDefaultConfigPath, readConfigFromFile } from '../lib/config';
 
-const config = readConfigFromFile(getDefaultConfigPath());
-cli(config);
+try {
+  const config = readConfigFromFile(getDefaultConfigPath());
+  cli(config);
+} catch {
+  cli();
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import { MongoClientOptions } from 'mongodb';
 import { getDbFromUri } from './utils/getDbFromUri';
-import { ConfigFileNotFoundError } from './errors/ConfigFileNotFoundError';
+import { ConfigFileNotFoundError } from './errors';
 import * as path from 'path';
 
 const DEFAULT_MIGRATIONS_COLLECTION = 'migrations_changelog';

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import { MongoClientOptions } from 'mongodb';
 import { getDbFromUri } from './utils/getDbFromUri';
+import { ConfigFileNotFoundError } from './errors/ConfigFileNotFoundError';
 import * as path from 'path';
 
 const DEFAULT_MIGRATIONS_COLLECTION = 'migrations_changelog';
@@ -32,7 +33,7 @@ export interface Config {
 
 export const readConfigFromFile = (filePath: string): Config => {
   if (!fs.existsSync(filePath)) {
-    throw new Error(`Config file ${filePath} not found.`);
+    throw new ConfigFileNotFoundError(`Config file ${filePath} not found.`);
   }
 
   const rawConfig = fs.readFileSync(filePath).toString();

--- a/lib/errors/ConfigFileNotFoundError.ts
+++ b/lib/errors/ConfigFileNotFoundError.ts
@@ -1,0 +1,5 @@
+export class ConfigFileNotFoundError extends Error {
+  constructor(error: string) {
+    super(error);
+  }
+}

--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -1,2 +1,3 @@
 export * from './ExecuteMigrationError';
 export * from './DbConnectionError';
+export * from './ConfigFileNotFoundError';


### PR DESCRIPTION
This PR fixes issue #32.

 In short, we can load the cli with or without config. If the cli is loaded without, then the only available command is to run `init` to generate the files the rest of the commands need.