### PR TITLE
feat: Add ability to pass a template file to the `new` command

### DIFF
--- a/__tests__/new.test.ts
+++ b/__tests__/new.test.ts
@@ -19,6 +19,7 @@ describe('new command', () => {
   beforeEach(() => {
     mkdirSyncSpy.mockReset();
     writeFileSyncSpy.mockReset();
+    defaultTemplateSpy.mockReset();
   });
 
   it('should create a new migration file', () => {
@@ -65,28 +66,13 @@ describe('new command', () => {
     );
   });
 
-  it('should use the default template text if template file does not exist', () => {
-    const defaultTemplateText = 'default template file contents';
-
+  it('should throw error if provided template file does not exist', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(false);
-    (newModule.defaultMigrationTemplate as jest.Mock).mockReturnValue(
-      defaultTemplateText
-    );
 
-    newModule.newCommand({
-      migrationsDir: configMock.migrationsDir,
-      templateFile: 'doesNotExist.ts',
-    });
+    expect(newModule.newCommand).toThrowError();
 
-    const fileName = `${+new Date()}_Migration`;
-
-    const expectedMigrationsPath = `${configMock.migrationsDir}/${fileName}.ts`;
-
-    expect(defaultTemplateSpy).toHaveBeenCalled();
-    expect(writeFileSyncSpy).toHaveBeenCalledWith(
-      expectedMigrationsPath,
-      defaultTemplateText
-    );
+    expect(defaultTemplateSpy).not.toHaveBeenCalled();
+    expect(writeFileSyncSpy).not.toHaveBeenCalled();
   });
 
   it('should use the default template text if no template file provided', () => {

--- a/__tests__/new.test.ts
+++ b/__tests__/new.test.ts
@@ -2,12 +2,19 @@ jest.mock('fs');
 jest.mock('../lib/config');
 
 import * as fs from 'fs';
-import { newCommand } from '../lib/commands/new';
+import * as newModule from '../lib/commands/new';
 import { configMock } from './__mocks__/config.mock';
 
 describe('new command', () => {
   const mkdirSyncSpy = jest.spyOn(fs, 'mkdirSync');
   const writeFileSyncSpy = jest.spyOn(fs, 'writeFileSync');
+  const defaultTemplateSpy = jest.spyOn(newModule, 'defaultMigrationTemplate');
+
+  beforeAll(() => {
+    jest
+      .useFakeTimers()
+      .setSystemTime(new Date('2022-01-01 00:00:00.000').getTime());
+  });
 
   beforeEach(() => {
     mkdirSyncSpy.mockReset();
@@ -17,7 +24,10 @@ describe('new command', () => {
   it('should create a new migration file', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(true);
     const migrationName = 'TestMigration';
-    newCommand({ migrationName, migrationsDir: configMock.migrationsDir });
+    newModule.newCommand({
+      migrationName,
+      migrationsDir: configMock.migrationsDir,
+    });
 
     expect(writeFileSyncSpy).toHaveBeenCalled();
   });
@@ -26,9 +36,56 @@ describe('new command', () => {
     (fs.existsSync as jest.Mock).mockReturnValue(false);
 
     const migrationName = 'TestMigration';
-    newCommand({ migrationName, migrationsDir: configMock.migrationsDir });
+    newModule.newCommand({
+      migrationName,
+      migrationsDir: configMock.migrationsDir,
+    });
 
     expect(mkdirSyncSpy).toHaveBeenCalledWith(configMock.migrationsDir);
     expect(writeFileSyncSpy).toHaveBeenCalled();
+  });
+
+  it('should create the migration using a template if the provided file exists', () => {
+    const templateFileText = 'custom template file contents';
+
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fs.readFileSync as jest.Mock).mockReturnValue(templateFileText);
+
+    const templateFile = 'testFile.ts';
+    newModule.newCommand({
+      migrationsDir: configMock.migrationsDir,
+      templateFile: templateFile,
+    });
+    const fileName = `${+new Date()}_Migration`;
+    const expectedMigrationsPath = `${configMock.migrationsDir}/${fileName}.ts`;
+
+    expect(writeFileSyncSpy).toHaveBeenCalledWith(
+      expectedMigrationsPath,
+      templateFileText
+    );
+  });
+
+  it('should use the default template text if template file does not exist', () => {
+    const defaultTemplateText = 'default template file contents';
+
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
+    (newModule.defaultMigrationTemplate as jest.Mock).mockReturnValue(
+      defaultTemplateText
+    );
+
+    newModule.newCommand({
+      migrationsDir: configMock.migrationsDir,
+      templateFile: 'doesNotExist.ts',
+    });
+
+    const fileName = `${+new Date()}_Migration`;
+
+    const expectedMigrationsPath = `${configMock.migrationsDir}/${fileName}.ts`;
+
+    expect(defaultTemplateSpy).toHaveBeenCalled();
+    expect(writeFileSyncSpy).toHaveBeenCalledWith(
+      expectedMigrationsPath,
+      defaultTemplateText
+    );
   });
 });

--- a/__tests__/new.test.ts
+++ b/__tests__/new.test.ts
@@ -88,4 +88,27 @@ describe('new command', () => {
       defaultTemplateText
     );
   });
+
+  it('should use the default template text if no template file provided', () => {
+    const defaultTemplateText = 'default template file contents';
+
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
+    (newModule.defaultMigrationTemplate as jest.Mock).mockReturnValue(
+      defaultTemplateText
+    );
+
+    newModule.newCommand({
+      migrationsDir: configMock.migrationsDir,
+    });
+
+    const fileName = `${+new Date()}_Migration`;
+
+    const expectedMigrationsPath = `${configMock.migrationsDir}/${fileName}.ts`;
+
+    expect(defaultTemplateSpy).toHaveBeenCalled();
+    expect(writeFileSyncSpy).toHaveBeenCalledWith(
+      expectedMigrationsPath,
+      defaultTemplateText
+    );
+  });
 });

--- a/__tests__/new.test.ts
+++ b/__tests__/new.test.ts
@@ -46,23 +46,25 @@ describe('new command', () => {
     expect(writeFileSyncSpy).toHaveBeenCalled();
   });
 
-  it('should create the migration using a template if the provided file exists', () => {
-    const templateFileText = 'custom template file contents';
+  it('should create the migration using a template if the provided file exists and replace the class name', () => {
+    const templateFileText = 'class custom template file contents';
 
     (fs.existsSync as jest.Mock).mockReturnValue(true);
     (fs.readFileSync as jest.Mock).mockReturnValue(templateFileText);
 
+    const newDate = +new Date();
     const templateFile = 'testFile.ts';
     newModule.newCommand({
       migrationsDir: configMock.migrationsDir,
       templateFile: templateFile,
     });
-    const fileName = `${+new Date()}_Migration`;
+    const fileName = `${newDate}_Migration`;
     const expectedMigrationsPath = `${configMock.migrationsDir}/${fileName}.ts`;
+    const expectedTemplateFileText = `class Migration${newDate} template file contents`;
 
     expect(writeFileSyncSpy).toHaveBeenCalledWith(
       expectedMigrationsPath,
-      templateFileText
+      expectedTemplateFileText
     );
   });
 

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -24,16 +24,26 @@ export const cli = (config?: Config): void => {
       .description('Create a new migration file under migrations directory')
       .storeOptionsAsProperties(false)
       .option('-n, --name <name>', 'the migration name')
+      .option('-t, --template-file <path>', 'The template file to use')
       .action((opts) => {
         let name = opts.name;
+        let templateFile = opts.templateFile;
 
         if (typeof opts.name !== 'string' || opts.name.length === 0) {
           name = undefined;
         }
 
+        if (
+          typeof opts.templateFile !== 'string' ||
+          opts.templateFile.length === 0
+        ) {
+          templateFile = undefined;
+        }
+
         newCommand({
           migrationName: name,
           migrationsDir: config.migrationsDir,
+          templateFile: templateFile,
         });
       });
 

--- a/lib/commands/new.ts
+++ b/lib/commands/new.ts
@@ -24,7 +24,7 @@ export class ${className} implements MigrationInterface {
 export const getMigrationTemplate = (
   className: string,
   templateFile?: string
-) => {
+): string => {
   if (!templateFile) {
     return defaultMigrationTemplate(className);
   }
@@ -47,7 +47,7 @@ export const newCommand = (opts: CommandNewOptions): string => {
   const fileName = `${+new Date()}_${migrationName || 'Migration'}`;
   const className = `${migrationName || 'Migration'}${+new Date()}`;
 
-  const template: string = getMigrationTemplate(className, templateFile);
+  const template = getMigrationTemplate(className, templateFile);
 
   const migrationPath = `${migrationsDir}/${fileName}.ts`;
 

--- a/lib/commands/new.ts
+++ b/lib/commands/new.ts
@@ -21,10 +21,18 @@ export class ${className} implements MigrationInterface {
 `;
 };
 
-export const getMigrationTemplate = (templateFile?: string) => {
-  if (templateFile && fs.existsSync(templateFile)) {
+export const getMigrationTemplate = (
+  className: string,
+  templateFile?: string
+) => {
+  if (!templateFile) {
+    return defaultMigrationTemplate(className);
+  }
+
+  if (fs.existsSync(templateFile)) {
     return fs.readFileSync(templateFile).toString();
   }
+
   throw new TemplateFileNotFoundError(
     `Template file ${templateFile} not found`
   );
@@ -36,15 +44,10 @@ export const newCommand = (opts: CommandNewOptions): string => {
   if (!fs.existsSync(migrationsDir)) {
     fs.mkdirSync(migrationsDir);
   }
-  let template: string;
   const fileName = `${+new Date()}_${migrationName || 'Migration'}`;
   const className = `${migrationName || 'Migration'}${+new Date()}`;
 
-  if (!templateFile) {
-    template = defaultMigrationTemplate(className);
-  } else {
-    template = getMigrationTemplate(templateFile);
-  }
+  const template: string = getMigrationTemplate(className, templateFile);
 
   const migrationPath = `${migrationsDir}/${fileName}.ts`;
 

--- a/lib/commands/new.ts
+++ b/lib/commands/new.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import { TemplateFileNotFoundError } from '../errors';
 
 interface CommandNewOptions {
   migrationsDir: string;
@@ -20,6 +21,15 @@ export class ${className} implements MigrationInterface {
 `;
 };
 
+export const getMigrationTemplate = (templateFile?: string) => {
+  if (templateFile && fs.existsSync(templateFile)) {
+    return fs.readFileSync(templateFile).toString();
+  }
+  throw new TemplateFileNotFoundError(
+    `Template file ${templateFile} not found`
+  );
+};
+
 export const newCommand = (opts: CommandNewOptions): string => {
   const { migrationName, migrationsDir, templateFile } = opts;
 
@@ -30,11 +40,12 @@ export const newCommand = (opts: CommandNewOptions): string => {
   const fileName = `${+new Date()}_${migrationName || 'Migration'}`;
   const className = `${migrationName || 'Migration'}${+new Date()}`;
 
-  if (templateFile && fs.existsSync(templateFile)) {
-    template = fs.readFileSync(templateFile).toString();
-  } else {
+  if (!templateFile) {
     template = defaultMigrationTemplate(className);
+  } else {
+    template = getMigrationTemplate(templateFile);
   }
+
   const migrationPath = `${migrationsDir}/${fileName}.ts`;
 
   fs.writeFileSync(migrationPath, template);

--- a/lib/commands/new.ts
+++ b/lib/commands/new.ts
@@ -30,7 +30,8 @@ export const getMigrationTemplate = (
   }
 
   if (fs.existsSync(templateFile)) {
-    return fs.readFileSync(templateFile).toString();
+    const template: string = fs.readFileSync(templateFile).toString();
+    return template.replace(/class (\S*) /, `class ${className} `);
   }
 
   throw new TemplateFileNotFoundError(

--- a/lib/commands/new.ts
+++ b/lib/commands/new.ts
@@ -3,9 +3,10 @@ import * as fs from 'fs';
 interface CommandNewOptions {
   migrationsDir: string;
   migrationName?: string;
+  templateFile?: string;
 }
 
-export const migrationTemplate = (className: string) => {
+export const defaultMigrationTemplate = (className: string) => {
   return `import { Db } from 'mongodb'
 import { MigrationInterface } from 'mongo-migrate-ts';
 
@@ -20,15 +21,21 @@ export class ${className} implements MigrationInterface {
 };
 
 export const newCommand = (opts: CommandNewOptions): string => {
-  const { migrationName, migrationsDir } = opts;
+  const { migrationName, migrationsDir, templateFile } = opts;
 
   if (!fs.existsSync(migrationsDir)) {
     fs.mkdirSync(migrationsDir);
   }
-
+  let template: string;
   const fileName = `${+new Date()}_${migrationName || 'Migration'}`;
   const className = `${migrationName || 'Migration'}${+new Date()}`;
-  const template = migrationTemplate(className);
+  console.log(templateFile);
+
+  if (templateFile && fs.existsSync(templateFile)) {
+    template = fs.readFileSync(templateFile).toString();
+  } else {
+    template = defaultMigrationTemplate(className);
+  }
   const migrationPath = `${migrationsDir}/${fileName}.ts`;
 
   fs.writeFileSync(migrationPath, template);

--- a/lib/commands/new.ts
+++ b/lib/commands/new.ts
@@ -29,7 +29,6 @@ export const newCommand = (opts: CommandNewOptions): string => {
   let template: string;
   const fileName = `${+new Date()}_${migrationName || 'Migration'}`;
   const className = `${migrationName || 'Migration'}${+new Date()}`;
-  console.log(templateFile);
 
   if (templateFile && fs.existsSync(templateFile)) {
     template = fs.readFileSync(templateFile).toString();

--- a/lib/errors/TemplateFileNotFoundError.ts
+++ b/lib/errors/TemplateFileNotFoundError.ts
@@ -1,0 +1,5 @@
+export class TemplateFileNotFoundError extends Error {
+  constructor(error: string) {
+    super(error);
+  }
+}

--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -1,3 +1,4 @@
 export * from './ExecuteMigrationError';
 export * from './DbConnectionError';
 export * from './ConfigFileNotFoundError';
+export * from './TemplateFileNotFoundError';


### PR DESCRIPTION
This PR adds the ability to pass an option `-t` or `--template-file` to the new command to use when generating a new migration file. 

If no file is passed or the file does not exist, we generate the file using the default template (which has been the functionality thus far) 

This is a feature requested in issue #43 