### PR TITLE
chore: Highlight access to client instance and apply 'void | never' as output type for MigrationInterface public methods

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,8 @@
 {
   "parser": "@typescript-eslint/parser",
-  "extends": ["plugin:@typescript-eslint/recommended", "prettier"]
+  "extends": ["plugin:@typescript-eslint/recommended", "prettier"],
+  "rules": {
+    "@typescript-eslint/no-unused-vars": [
+      "error", { "ignoreRestSiblings": true, "argsIgnorePattern": "^_" }]
+  }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,4 @@
 {
   "parser": "@typescript-eslint/parser",
-  "extends": ["plugin:@typescript-eslint/recommended", "prettier"],
-  "rules": {
-    "@typescript-eslint/no-unused-vars": [
-      "error", { "ignoreRestSiblings": true, "argsIgnorePattern": "^_" }]
-  }
+  "extends": ["plugin:@typescript-eslint/recommended", "prettier"]
 }

--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ Create a migration file in the configured migrations folder...
 
 ```typescript
 import { MigrationInterface } from 'mongo-migrate-ts';
-import { Db } from 'mongodb';
+import { Db, MongoClient } from 'mongodb';
 
 export class MyMigration implements MigrationInterface {
-  async up(db: Db): Promise<void | never> {
+  async up(db: Db, client: MongoClient): Promise<void | never> {
     await db.createCollection('my_collection');
   }
 
-  async down(db: Db): Promise<void | never> {
+  async down(db: Db, client: MongoClient): Promise<void | never> {
     await db.dropCollection('my_collection');
   }
 }

--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ import { MigrationInterface } from 'mongo-migrate-ts';
 import { Db } from 'mongodb';
 
 export class MyMigration implements MigrationInterface {
-  async up(db: Db): Promise<any> {
+  async up(db: Db): Promise<void | never> {
     await db.createCollection('my_collection');
   }
 
-  async down(db: Db): Promise<any> {
+  async down(db: Db): Promise<void | never> {
     await db.dropCollection('my_collection');
   }
 }
@@ -130,7 +130,7 @@ import { Db, MongoClient } from 'mongodb';
 import { MigrationInterface } from '../../lib';
 
 export class Transaction1691171075957 implements MigrationInterface {
-  public async up(db: Db, client: MongoClient): Promise<any> {
+  public async up(db: Db, client: MongoClient): Promise<void | never> {
     const session = client.startSession();
     try {
       await session.withTransaction(async () => {
@@ -143,7 +143,7 @@ export class Transaction1691171075957 implements MigrationInterface {
     }
   }
 
-  public async down(db: Db, client: MongoClient): Promise<any> {
+  public async down(db: Db, client: MongoClient): Promise<void | never> {
     const session = client.startSession();
     try {
       await session.withTransaction(async () => {

--- a/examples/migrations/1585933701415_Migration.ts
+++ b/examples/migrations/1585933701415_Migration.ts
@@ -1,12 +1,12 @@
-import { Db, MongoClient } from 'mongodb';
+import { Db } from 'mongodb';
 import { MigrationInterface } from '../../lib';
 
 export class Migration1585933701415 implements MigrationInterface {
-  public async up(db: Db, _client: MongoClient): Promise<void | never> {
+  public async up(db: Db): Promise<void | never> {
     await db.createCollection('mycol');
   }
 
-  public async down(db: Db, _client: MongoClient): Promise<void | never> {
+  public async down(db: Db): Promise<void | never> {
     await db.dropCollection('mycol');
   }
 }

--- a/examples/migrations/1585933701415_Migration.ts
+++ b/examples/migrations/1585933701415_Migration.ts
@@ -1,12 +1,12 @@
-import { Db } from 'mongodb';
+import { Db, MongoClient } from 'mongodb';
 import { MigrationInterface } from '../../lib';
 
 export class Migration1585933701415 implements MigrationInterface {
-  public async up(db: Db): Promise<void> {
-    db.createCollection('mycol');
+  public async up(db: Db, _client: MongoClient): Promise<void | never> {
+    await db.createCollection('mycol');
   }
 
-  public async down(db: Db): Promise<void> {
-    db.dropCollection('mycol');
+  public async down(db: Db, _client: MongoClient): Promise<void | never> {
+    await db.dropCollection('mycol');
   }
 }

--- a/examples/migrations/1691171075957_Transaction.ts
+++ b/examples/migrations/1691171075957_Transaction.ts
@@ -2,7 +2,7 @@ import { Db, MongoClient } from 'mongodb';
 import { MigrationInterface } from '../../lib';
 
 export class Transaction1691171075957 implements MigrationInterface {
-  public async up(db: Db, client: MongoClient): Promise<void> {
+  public async up(db: Db, client: MongoClient): Promise<void | never> {
     const session = client.startSession();
     try {
       await session.withTransaction(async () => {
@@ -15,7 +15,7 @@ export class Transaction1691171075957 implements MigrationInterface {
     }
   }
 
-  public async down(db: Db, client: MongoClient): Promise<void> {
+  public async down(db: Db, client: MongoClient): Promise<void | never> {
     const session = client.startSession();
     try {
       await session.withTransaction(async () => {

--- a/lib/MigrationInterface.ts
+++ b/lib/MigrationInterface.ts
@@ -1,6 +1,6 @@
 import { Db, MongoClient } from 'mongodb';
 
 export interface MigrationInterface {
-  up(db: Db, client: MongoClient): Promise<void>;
-  down(db: Db, client: MongoClient): Promise<void>;
+  up(db: Db, client: MongoClient): Promise<void | never>;
+  down(db: Db, client: MongoClient): Promise<void | never>;
 }

--- a/lib/commands/new.ts
+++ b/lib/commands/new.ts
@@ -8,14 +8,14 @@ interface CommandNewOptions {
 }
 
 export const defaultMigrationTemplate = (className: string) => {
-  return `import { Db } from 'mongodb'
+  return `import { Db, MongoClient } from 'mongodb';
 import { MigrationInterface } from 'mongo-migrate-ts';
 
 export class ${className} implements MigrationInterface {
-  public async up(db: Db): Promise<void | never> {
+  public async up(db: Db, client: MongoClient): Promise<void | never> { {
   }
 
-  public async down(db: Db): Promise<void | never> {
+  public async down(db: Db, client: MongoClient): Promise<void | never> {
   }
 }
 `;

--- a/lib/commands/new.ts
+++ b/lib/commands/new.ts
@@ -10,14 +10,14 @@ interface CommandNewOptions {
 }
 
 export const defaultMigrationTemplate = (className: string) => {
-  return `import { Db, MongoClient } from 'mongodb';
+  return `import { Db } from 'mongodb';
 import { MigrationInterface } from 'mongo-migrate-ts';
 
 export class ${className} implements MigrationInterface {
-  public async up(db: Db, client: MongoClient): Promise<void | never> { {
+  public async up(db: Db): Promise<void | never> {
   }
 
-  public async down(db: Db, client: MongoClient): Promise<void | never> {
+  public async down(db: Db): Promise<void | never> {
   }
 }
 `;

--- a/lib/commands/new.ts
+++ b/lib/commands/new.ts
@@ -12,10 +12,10 @@ export const defaultMigrationTemplate = (className: string) => {
 import { MigrationInterface } from 'mongo-migrate-ts';
 
 export class ${className} implements MigrationInterface {
-  public async up(db: Db): Promise<any> {
+  public async up(db: Db): Promise<void | never> {
   }
 
-  public async down(db: Db): Promise<any> {
+  public async down(db: Db): Promise<void | never> {
   }
 }
 `;


### PR DESCRIPTION
- ~Unify arguments and types for MigrationInterface public methods everywhere (doc/template/declare)~ 
[In README] Highlight access to `client` instance as the second argument for migration methods.
- Apply `| never` type for MigrationInterface public methods due to error possibility during execution.