### PR TITLE
feat: sort migrations before applying

### DIFF
--- a/lib/commands/up.ts
+++ b/lib/commands/up.ts
@@ -40,12 +40,23 @@ export const up = async (opts: CommandUpOptions): Promise<void> => {
       globPattern,
       globOptions
     );
-    const migrations = migrationObjs.filter(
-      (migration: MigrationObject) =>
-        appliedMigrations.find(
-          (m: MigrationModel) => m.className === migration.className
-        ) === undefined
-    );
+    const migrations = migrationObjs
+      .filter(
+        (migration: MigrationObject) =>
+          appliedMigrations.find(
+            (m: MigrationModel) => m.className === migration.className
+          ) === undefined
+      )
+      .sort((a, b): number => {
+        // sort migrations by timestamp before applying
+        const aTimestamp = Number(
+          a.className.substring(a.className.length - 13)
+        );
+        const bTimestamp = Number(
+          b.className.substring(a.className.length - 13)
+        );
+        return aTimestamp > bTimestamp ? 1 : -1;
+      });
 
     if (migrations.length === 0) {
       spinner.warn('No migrations found').stop();

--- a/lib/commands/up.ts
+++ b/lib/commands/up.ts
@@ -47,16 +47,7 @@ export const up = async (opts: CommandUpOptions): Promise<void> => {
             (m: MigrationModel) => m.className === migration.className
           ) === undefined
       )
-      .sort((a, b): number => {
-        // sort migrations by timestamp before applying
-        const aTimestamp = Number(
-          a.className.substring(a.className.length - 13)
-        );
-        const bTimestamp = Number(
-          b.className.substring(a.className.length - 13)
-        );
-        return aTimestamp > bTimestamp ? 1 : -1;
-      });
+      .sort((a, b) => a.className.localeCompare(b.className));
 
     if (migrations.length === 0) {
       spinner.warn('No migrations found').stop();

--- a/lib/utils/timestamp.ts
+++ b/lib/utils/timestamp.ts
@@ -3,13 +3,13 @@ import { format } from 'date-fns';
 export const timestamp = (dateFormat: string, date = new Date()): string => {
   return format(
     new Date(
-      date.getUTCFullYear(),
-      date.getUTCMonth(),
-      date.getUTCDate(),
-      date.getUTCHours(),
-      date.getUTCMinutes(),
-      date.getUTCSeconds(),
-      date.getUTCMilliseconds()
+      date.getFullYear(),
+      date.getMonth(),
+      date.getDate(),
+      date.getHours(),
+      date.getMinutes(),
+      date.getSeconds(),
+      date.getMilliseconds()
     ),
     dateFormat
   );


### PR DESCRIPTION
# Problem Description

Migration files are not ordered by timestamp when running `up`-command which can cause ordering issues.

For example
Migration1: createCollection
Migration2: change stuff within collection

If not ordered, migration-stuff attempts to run first and fails due to dependency on Migration1 (or collection existing)
```
ExecuteMigrationError: MongoServerError: ns does not exist: db.collection
```

# Solution

When creating a migration file, we know that all class names end with a 13-digit timestamp (`./lib/commands/new.ts:57`) regardless of using a custom template or the default one.

We can therefore extract timestamp from className (last 13 digits of className) and sort migrations based on this before running migrations.