### PR TITLE
fix: sort migrations by timestamp from className

### DIFF
--- a/examples/migrations/1713446102472_InsertRandomData.ts
+++ b/examples/migrations/1713446102472_InsertRandomData.ts
@@ -1,0 +1,14 @@
+import { Db } from 'mongodb';
+import { MigrationInterface } from '../../lib';
+
+export class InsertRandomData1713446102472 implements MigrationInterface {
+  public async up(db: Db): Promise<void | never> {
+    const col = db.collection('mycol');
+    await col.insertMany([{ a: 1 }, { a: 2 }, { a: 3 }]);
+  }
+
+  public async down(db: Db): Promise<void | never> {
+    const col = db.collection('mycol');
+    await col.deleteMany({ a: { $in: [1, 2, 3] } });
+  }
+}

--- a/lib/commands/up.ts
+++ b/lib/commands/up.ts
@@ -47,7 +47,16 @@ export const up = async (opts: CommandUpOptions): Promise<void> => {
             (m: MigrationModel) => m.className === migration.className
           ) === undefined
       )
-      .sort((a, b) => a.className.localeCompare(b.className));
+      .sort((a, b): number => {
+        // sort migrations by timestamp before applying
+        const aTimestamp = Number(
+          a.className.substring(a.className.length - 13)
+        );
+        const bTimestamp = Number(
+          b.className.substring(b.className.length - 13)
+        );
+        return aTimestamp > bTimestamp ? 1 : -1;
+      });
 
     if (migrations.length === 0) {
       spinner.warn('No migrations found').stop();


### PR DESCRIPTION
Should close #113 and #114

Thanks to @sf0rman as it was originally his change that I messed up.