### PR TITLE
feat: upgrade mongodb driver to v7 for mongoose 9 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,11 @@ version: 2.1
 executors:
   node:
     docker:
-      - image: cimg/node:20.12
+      - image: cimg/node:20.19
   node-with-mongo:
     docker:
-      - image: cimg/node:20.12
-      - image: mongo:6.0
+      - image: cimg/node:20.19
+      - image: mongo:7.0
         environment:
           MONGO_INITDB_ROOT_USERNAME: admin
           MONGO_INITDB_ROOT_PASSWORD: admin

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/cli-table": "^0.3.1",
     "@types/commander": "^2.12.2",
     "@types/jest": "^27.4.0",
-    "@types/node": "^17.0.13",
+    "@types/node": "^25.0.8",
     "@typescript-eslint/eslint-plugin": "^5.10.1",
     "@typescript-eslint/parser": "^5.10.1",
     "eslint": "^8.8.0",
@@ -62,7 +62,7 @@
     "ora": "5.4.1"
   },
   "peerDependencies": {
-    "mongodb": "4.x.x || 5.x.x || 6.x.x"
+    "mongodb": "4.x.x || 5.x.x || 6.x.x || 7.x.x"
   },
   "lint-staged": {
     "*.{ts,js}": [

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "husky": "^8.0.3",
     "jest": "^29.5.0",
     "lint-staged": "^12.3.2",
-    "mongodb": "^6.2.0",
+    "mongodb": "^7.0.0",
     "prettier": "^2.5.1",
     "rimraf": "^4.4.0",
     "rollup": "^4.24.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "dist",
     "module": "commonjs",
     "target": "esnext",
-    "lib": ["es6"],
+    "lib": ["ESNext"],
     "sourceMap": true,
     "esModuleInterop": true,
     "moduleResolution": "node",


### PR DESCRIPTION
Description
Upgrades mongodb driver from v6 to v7 for compatibility with Mongoose 9.x which requires bson 7.x.

Changes
Updated mongodb dependency to ^7.0.0

Testing
All existing tests pass.